### PR TITLE
Add DeriveGeneric and base >=4.5

### DIFF
--- a/math-functions.cabal
+++ b/math-functions.cabal
@@ -36,9 +36,10 @@ library
     ScopedTypeVariables
     TemplateHaskell
     TypeFamilies
+    DeriveGeneric
 
   ghc-options:          -Wall -O2
-  build-depends:        base >=3 && <5,
+  build-depends:        base >=4.5 && <5,
                         deepseq,
                         vector >= 0.7,
                         primitive,


### PR DESCRIPTION
- base-4.5 is needed because before `Num` had `Eq` and `Show` superclasses
- `DeriveGeneric` is used, so it's good to list.