### PR TITLE
Fix licsense attribute in math-functions.cabal

### DIFF
--- a/math-functions.cabal
+++ b/math-functions.cabal
@@ -1,7 +1,7 @@
 name:           math-functions
 version:        0.3.0.1
 cabal-version:  >= 1.10
-license:        BSD3
+license:        BSD2
 license-file:   LICENSE
 author:         Bryan O'Sullivan <bos@serpentine.com>,
                 Alexey Khudyakov <alexey.skladnoy@gmail.com>


### PR DESCRIPTION
The LICENSE file says BSD2, but the Cabal file says BSD3. I suppose the LICENSE file is correct.